### PR TITLE
add additional constraints to collision checking in motion planning

### DIFF
--- a/src/pybullet_helpers/motion_planning.py
+++ b/src/pybullet_helpers/motion_planning.py
@@ -55,7 +55,9 @@ def run_motion_planning(
     False behaves as if a collision check failed. For example, if you
     want to make sure that a held object is not rotated beyond some
     threshold, you could use additional_state_constraint_fn to enforce
-    that.
+    that. The additional state constraint function can assume that the
+    robot is already in the given joint positions because it will be
+    called right after collision checking, which sets the robot state.
     """
     if hyperparameters is None:
         hyperparameters = MotionPlanningHyperparameters()
@@ -75,7 +77,8 @@ def run_motion_planning(
         base_link_to_held_obj,
     )
     if additional_state_constraint_fn is not None:
-        _collision_fn = lambda x: _collision_fn(
+        _initial_collision_fn = _collision_fn
+        _collision_fn = lambda x: _initial_collision_fn(
             x
         ) or not additional_state_constraint_fn(x)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,9 @@ def _connect_to_pybullet():
     This fixture automatically disconnects the physics server, so we
     don't forget to do it ourselves.
     """
+    # Uncomment for debugging.
+    # from pybullet_helpers.gui import create_gui_connection
+    # physics_client_id = create_gui_connection(camera_yaw=180)
     physics_client_id = p.connect(p.DIRECT)
     yield physics_client_id
     p.disconnect(physics_client_id)


### PR DESCRIPTION
the implementation seems to work, but the rejection sampling is too naive. will try a projection-based or direct method in the future.

reference: https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://arm.robotics.umich.edu/download.php%3Fp%3D65&ved=2ahUKEwj-39jjhPOHAxWZv4kEHSkZIlAQFnoECAwQAQ&usg=AOvVaw34TKOsjK3wwMCbsnl5oCWP