### PR TITLE
add utility for rotating a pose around a point

### DIFF
--- a/src/pybullet_helpers/math_utils.py
+++ b/src/pybullet_helpers/math_utils.py
@@ -2,7 +2,13 @@
 
 import numpy as np
 
-from pybullet_helpers.geometry import Pose, quat_from_matrix
+from pybullet_helpers.geometry import (
+    Pose,
+    Pose3D,
+    Quaternion,
+    matrix_from_quat,
+    quat_from_matrix,
+)
 
 
 def get_poses_facing_line(
@@ -54,3 +60,27 @@ def get_poses_facing_line(
         poses.append(Pose(position=tuple(position), orientation=orientation))
 
     return poses
+
+
+def rotate_about_point(point: Pose3D, rotation: Quaternion, current_pose: Pose) -> Pose:
+    """Rotate a current pose by a given rotation around a point."""
+
+    # First rotate the current position.
+    current_position = current_pose.position
+
+    # Translate the current_position.
+    translated_position = np.subtract(current_position, point)
+
+    # Apply the rotation.
+    rotation_matrix = matrix_from_quat(rotation)
+    rotated_position = rotation_matrix @ translated_position
+
+    # Translate back to original position.
+    new_position = tuple(rotated_position + point)
+
+    # Now rotate the current orientation.
+    current_orientation_matrix = matrix_from_quat(current_pose.orientation)
+    new_orientation_matrix = rotation_matrix @ current_orientation_matrix
+    new_orientation = quat_from_matrix(new_orientation_matrix)
+
+    return Pose(new_position, new_orientation)

--- a/src/pybullet_helpers/math_utils.py
+++ b/src/pybullet_helpers/math_utils.py
@@ -37,7 +37,7 @@ def get_poses_facing_line(
         ortho_vector = np.array([1, 0, 0])
     else:
         ortho_vector = np.cross(axis, [0, 0, 1])
-    assert np.isclose(np.linalg.norm(ortho_vector), 1.0)
+        ortho_vector = ortho_vector / np.linalg.norm(ortho_vector)
 
     # Compute points on the circle.
     poses = []

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -1,9 +1,10 @@
 """Tests for math_utils.py."""
 
 import numpy as np
+import pybullet as p
 
 from pybullet_helpers.geometry import Pose
-from pybullet_helpers.math_utils import get_poses_facing_line
+from pybullet_helpers.math_utils import get_poses_facing_line, rotate_about_point
 
 
 def test_get_poses_facing_line():
@@ -19,8 +20,8 @@ def test_get_poses_facing_line():
         Pose(position=(-1.0, 0.0, 0.0), orientation=(-0.5, 0.5, -0.5, 0.5)),
         Pose(position=(0.0, -1.0, -0.0), orientation=(-0.7071, 0.0, 0.0, 0.7071)),
     ]
-    for p, e in zip(poses, expected, strict=True):
-        assert p.allclose(e)
+    for pose, exp in zip(poses, expected, strict=True):
+        assert pose.allclose(exp)
 
     axis = (0.0, 0.0, 1.0)
     point_on_line = (10.0, 0.0, 0.0)
@@ -32,8 +33,8 @@ def test_get_poses_facing_line():
         Pose(position=(8.0, 0.0, 0.0), orientation=(-0.5, 0.5, -0.5, 0.5)),
         Pose(position=(10.0, -2.0, -0.0), orientation=(-0.7071, 0.0, 0.0, 0.7071)),
     ]
-    for p, e in zip(poses, expected, strict=True):
-        assert p.allclose(e)
+    for pose, exp in zip(poses, expected, strict=True):
+        assert pose.allclose(exp)
 
     axis = (1.0, 0.0, 0.0)
     point_on_line = (0.0, 0.0, 0.0)
@@ -45,8 +46,8 @@ def test_get_poses_facing_line():
         Pose(position=(0.0, 1.0, 0.0), orientation=(0.5, -0.5, 0.5, 0.5)),
         Pose(position=(0.0, 0.0, 1.0), orientation=(0.707107, -0.707107, 0.0, 0.0)),
     ]
-    for p, e in zip(poses, expected, strict=True):
-        assert p.allclose(e)
+    for pose, exp in zip(poses, expected, strict=True):
+        assert pose.allclose(exp)
 
     # Test angle_offset.
     axis = (0.0, 0.0, 1.0)
@@ -61,11 +62,10 @@ def test_get_poses_facing_line():
         Pose(position=(0.0, -1.0, 0.0), orientation=(-0.707107, 0.0, 0.0, 0.707107)),
         Pose(position=(1.0, 0.0, 0.0), orientation=(-0.5, -0.5, 0.5, 0.5)),
     ]
-    for p, e in zip(poses, expected, strict=True):
-        assert p.allclose(e)
+    for pose, exp in zip(poses, expected, strict=True):
+        assert pose.allclose(exp)
 
     # Uncomment to debug.
-    # import pybullet as p
     # from pybullet_helpers.gui import create_gui_connection, visualize_pose
 
     # physics_client_id = create_gui_connection(camera_target=point_on_line)
@@ -78,5 +78,32 @@ def test_get_poses_facing_line():
     # )
     # for pose in poses:
     #     visualize_pose(pose, physics_client_id)
+    # while True:
+    #     p.stepSimulation(physicsClientId=physics_client_id)
+
+
+def test_rotate_about_point():
+    """Tests for rotate_about_point()."""
+
+    point = (0.0, 0.0, 0.0)
+    current_pose = Pose((1.0, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0))
+    rotation = p.getQuaternionFromEuler((0.0, 0.0, np.pi))
+    rotated_pose = rotate_about_point(point, rotation, current_pose)
+    assert np.allclose(rotated_pose.position, (-1.0, 0.0, 0.0))
+    assert np.allclose(rotated_pose.orientation, (0.0, 0.0, 1.0, 0.0))
+
+    # Uncomment to debug.
+    # from pybullet_helpers.gui import create_gui_connection, visualize_pose
+
+    # physics_client_id = create_gui_connection(camera_target=point)
+    # p.addUserDebugPoints(
+    #     pointPositions=[point],
+    #     pointColorsRGB=[(1.0, 1.0, 1.0)],
+    #     pointSize=10.0,
+    #     lifeTime=0,
+    #     physicsClientId=physics_client_id,
+    # )
+    # visualize_pose(current_pose, physics_client_id)
+    # visualize_pose(rotated_pose, physics_client_id)
     # while True:
     #     p.stepSimulation(physicsClientId=physics_client_id)


### PR DESCRIPTION
this is helpful for rotating an entire scene and making sure that nothing breaks (e.g., due to transform bugs)